### PR TITLE
Implement protocol changes for old Daum devices

### DIFF
--- a/BLE/daumBLE.js
+++ b/BLE/daumBLE.js
@@ -2,6 +2,7 @@ const bleno = require('@abandonware/bleno');
 const EventEmitter = require('events');
 const CyclingPowerService = require('./cycling-power-service');
 const FitnessMachineService = require('./ftms-service');
+const HeartRateServiceService = require('./heart-rate-service');
 
 class DaumBLE extends EventEmitter {
   constructor (serverCallback) {
@@ -12,6 +13,7 @@ class DaumBLE extends EventEmitter {
 
     this.csp = new CyclingPowerService();
     this.ftms = new FitnessMachineService(serverCallback);
+    this.hrs = new HeartRateServiceService();
 
     let self = this;
     console.log(`[daumBLE.js] - ${this.name} - BLE server starting`);
@@ -24,7 +26,7 @@ class DaumBLE extends EventEmitter {
       self.emit('stateChange', state);
 
       if (state === 'poweredOn') {
-        bleno.startAdvertising(self.name, [self.csp.uuid, self.ftms.uuid]);
+        bleno.startAdvertising(self.name, [self.csp.uuid, self.ftms.uuid, self.hrs.uuid]);
       } else {
         console.log('Stopping...');
         bleno.stopAdvertising();
@@ -37,7 +39,7 @@ class DaumBLE extends EventEmitter {
       // self.emit('error', error)
 
       if (!error) {
-        bleno.setServices([self.csp, self.ftms],
+        bleno.setServices([self.csp, self.ftms, self.hrs],
           (error) => {
             console.log(`[daumBLE.js] - ${this.name} - setServices: ${(error ? 'error ' + error : 'success')}`)
           });
@@ -87,6 +89,7 @@ class DaumBLE extends EventEmitter {
   notifyFTMS (event) {
     this.csp.notify(event);
     this.ftms.notify(event);
+    this.hrs.notify(event);
   }
 }
 

--- a/BLE/daumBLE.js
+++ b/BLE/daumBLE.js
@@ -7,7 +7,7 @@ class DaumBLE extends EventEmitter {
   constructor (serverCallback) {
     super();
 
-    this.name = 'DAUM Ergobike 8008 TRS';
+    this.name = 'DAUM Ergobike';
     process.env['BLENO_DEVICE_NAME'] = this.name;
 
     this.csp = new CyclingPowerService();

--- a/BLE/heart-rate-characteristic.js
+++ b/BLE/heart-rate-characteristic.js
@@ -1,0 +1,55 @@
+const Bleno = require('@abandonware/bleno');
+const Logger = require('../logger');
+
+const logger = new Logger('heart-rate-characteristic.js');
+
+class HeartRateCharacteristic extends Bleno.Characteristic {
+  constructor () {
+    super({
+      uuid: '2A37',
+      value: null,
+      properties: ['notify'],
+      descriptors: [
+        new Bleno.Descriptor({
+          // Client Characteristic Configuration
+          uuid: '2901',
+          value: 'Heart Rate Measurement'
+        })
+      ]
+    });
+    this._updateValueCallback = null;
+  }
+
+  onSubscribe (maxValueSize, updateValueCallback) {
+    logger.debug('client subscribed');
+    this._updateValueCallback = updateValueCallback;
+    return this.RESULT_SUCCESS;
+  }
+
+  onUnsubscribe () {
+    logger.debug('client unsubscribed');
+    this._updateValueCallback = null;
+    return this.RESULT_UNLIKELY_ERROR;
+  }
+
+  notify (event) {
+    logger.debug('notify');
+    if ('hr' in event) {
+      const buffer = new Buffer.alloc(2); 
+      //logger.debug('hr: ' + event.hr);
+    
+      buffer.writeUInt8(0, 0);
+      buffer.writeUInt8(event.hr, 1);
+
+      if (this._updateValueCallback) {
+        this._updateValueCallback(buffer);
+      } else {
+        logger.debug('nobody is listening');
+      }
+    }
+
+    return this.RESULT_SUCCESS;
+  }
+}
+
+module.exports = HeartRateCharacteristic;

--- a/BLE/heart-rate-service.js
+++ b/BLE/heart-rate-service.js
@@ -1,0 +1,28 @@
+const Bleno = require('@abandonware/bleno');
+const HeartRateCharacteristic = require('./heart-rate-characteristic');
+
+
+class HeartRateService  extends Bleno.PrimaryService {
+  constructor () {
+    let heart_rate_characteristic = new HeartRateCharacteristic();
+
+    super({
+      uuid: '180d',
+      characteristics: [
+        heart_rate_characteristic,
+      ]
+    });
+
+    this.heart_rate_characteristic = heart_rate_characteristic;
+  }
+
+  /*
+   * Transfer event from daum USB to the given characteristics
+   */
+  notify (event) {
+    this.heart_rate_characteristic.notify(event);
+    return this.RESULT_SUCCESS;
+  }
+}
+
+module.exports = HeartRateService;

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 * forked from https://github.com/uhulahen/daumUSB2BLE
 * updated and fixed to work with the current version of Zwift on modern linux
 * extended with broadcasting of ride metrics via ANT+
+* added support for devices before 2001 (e.g. Ergobike Cardio, 4008 series, etc.)
 
 ## prerequisites
 * RS232 to USB converter
@@ -29,6 +30,7 @@ SUBSYSTEM=="tty", ATTRS{idVendor}=="067b", ATTRS{idProduct}=="23a3", SYMLINK+="t
 ```
 SUBSYSTEM=="usb", ATTR{idVendor}=="0fcf", ATTR{idProduct}=="1009", MODE="0660", GROUP="uucp"
 ```
+* if you are using an old Daum device from before 2001 (e.g. Ergobike Cardio, 4008 series, etc.) set the parameter old_protocol to true in the config.yml
 
 ### configure sim
 * if SIM mode is a feature you want to use, edit the parameters in config.yml to fit you
@@ -101,9 +103,9 @@ sudo systemctl status ergoFACE.service
 ```
 
 * plug the RS232 to USB converter in any USB port
-* start your Daum ergobike 8008 TRS
+* start your Daum ergobike
 * ergoFACE will lookup for the cockpit address and start receiving data
-* start an app like ZWIFT and your Daum bike will appear as "DAUM Ergobike 8008 TRS" device with two services (power & FTMS)
+* start an app like ZWIFT and your Daum bike will appear as "DAUM Ergobike" device with two services (power & FTMS)
 
 ## website / server
 * start your browser and enter "pi-address:3000" (try to get fixed IP address for you raspberry on your router before)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 * updated and fixed to work with the current version of Zwift on modern linux
 * extended with broadcasting of ride metrics via ANT+
 * added support for devices before 2001 (e.g. Ergobike Cardio, 4008 series, etc.)
+* updated heart rate reading from Daum Ergobike
+* added BLE heart rate monitoring service (thanks to https://github.com/StephenDone/daumUSB2BLE/)
 
 ## prerequisites
 * RS232 to USB converter

--- a/USB/daumUSB.js
+++ b/USB/daumUSB.js
@@ -184,7 +184,8 @@ class daumUSB {
       speed: global.globalspeed_daum,
       rpm: global.globalrpm_daum,
       gear: global.globalgear_daum,
-      power: global.globalpower_daum
+      power: global.globalpower_daum,
+      hr: global.globalhr_daum
     };
     let failure = false;
 
@@ -247,9 +248,7 @@ class daumUSB {
             // if (!isNaN(cadence) && (cadence >= config.daumRanges.min_rpm && cadence <= config.daumRanges.max_rpm)) {
             //   data.cadence = cadence
             // }
-            // const hr = 99 // !!! can be deleted - have to check BLE code on dependencies
-            // if (!isNaN(hr)) { data.hr = hr } // !!! can be deleted - have to check BLE code on dependencies
-            // TODO: check if we have to do a parseHexToInt here
+            
             const rpm = (states[6]);
             if (!isNaN(rpm) && (rpm >= config.daumRanges.min_rpm && rpm <= config.daumRanges.max_rpm)) {
               if (rpm - global.globalrpm_daum >= config.daumRanges.rpm_threshold) {
@@ -258,6 +257,18 @@ class daumUSB {
               } else {
                 data.rpm = rpm;
                 global.globalrpm_daum = data.rpm // global variables used, because I cannot code ;)
+              }
+            }
+
+            const hr = (states[14]);
+            logger.debug('hr: ' + hr);
+            if (!isNaN(hr) && (hr >= config.daumRanges.min_hr && hr <= config.daumRanges.max_hr)) {
+              if (failure) {
+                logger.debug('hr failure');
+                data.hr = global.globalhr_daum;
+              } else {
+                data.hr = hr;
+                global.globalhr_daum = data.hr
               }
             }
 
@@ -419,7 +430,7 @@ class daumUSB {
         logger.warn('[OUT]: Communication port is not open - not sending data: ' + element.command);
       }
     } else {
-      logger.debug('there is nothing in the queue.');
+      //logger.debug('there is nothing in the queue.');
       // TODO: get run data, because we have some time
       // this.runData();
     }

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
 DEBUG:
-    level: 3  # DEBUG
+    level: 0  # Error
 
 mock:
     daumUSB: false
@@ -11,6 +11,7 @@ globals:
     rpm_daum: 0
     gear_daum: 1
     power_daum: 0
+    hr_daum: 0
     windspeed_ble: 0
     grade_ble: 0
     crr_ble: 0.0040
@@ -142,6 +143,8 @@ daumRanges:
       max_gear: 28
       min_shift: 1
       max_shift: 5
+      min_hr: 0
+      max_hr: 250
       manual_program: 0
       min_program: 0
       max_program: 79

--- a/config.yml
+++ b/config.yml
@@ -23,6 +23,7 @@ server:
 
 port:
     baudrate: 9600
+    baudrate_old: 4800
     dataBits: 8
     parity: 'none'
     stopBits: 1
@@ -93,7 +94,8 @@ gpio:
     shiftDownPin: 17
 
 daumCockpit:
-    serialPath: '/dev/ttyDaumUsbSerial'
+    serialPath: '/dev/ttyUSB0'
+    old_protocol: true
     adress: '00'
     gotAdressSuccess: false
 

--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ global.globalspeed_daum = config.globals.speed_daum;
 global.globalrpm_daum = config.globals.rpm_daum;
 global.globalgear_daum = config.globals.gear_daum;
 global.globalpower_daum = config.globals.power_daum;
+global.globalhr_daum = config.globals.hr_daum;
 global.globalwindspeed_ble = config.globals.windspeed_ble;
 global.globalgrade_ble = config.globals.grade_ble;
 global.globalcrr_ble = config.globals.crr_ble;    // set once to have simulation available without BLE connected to apps
@@ -281,6 +282,7 @@ daumObs.on('data', data => {
   if ('rpm' in data) io.emit('rpm', data.rpm);
   if ('gear' in data) io.emit('gear', data.gear);
   if ('program' in data) io.emit('program', data.program);
+  if ('hr' in data) io.emit('hr', data.hr);
 
   daumBLE.notifyFTMS(data);
   daumAnt.notify(data);

--- a/test/test-ble.js
+++ b/test/test-ble.js
@@ -1,0 +1,29 @@
+const Logger = require('../logger');
+const logger = new Logger('test-ble.js');
+const DaumBLE = require('../BLE/daumBLE');
+
+let daumBLE = new DaumBLE(serverCallback)
+
+setInterval(callServer, 1000);
+
+function getRandomInt(max) {
+  return Math.floor(Math.random() * max);
+}
+
+function callServer() {
+  let data={};
+  data.hr=50 + getRandomInt(10);
+  data.rpm=50 + getRandomInt(10);
+  data.power=50 + getRandomInt(10);
+  data.speed=50 + getRandomInt(10);
+
+  logger.debug('data:' + JSON.stringify(data));
+  
+  daumBLE.notifyFTMS(data)
+}
+
+
+function serverCallback (message, ...args) {
+  let success = false;
+  return success;
+}


### PR DESCRIPTION
Unfortunately, my old Daum Electronic device "Ergobike Cardio" (comparable to the 4008 series and many other bikes) from before 2001 uses a slightly different RS232 protocol in some of the cases. Additionally, it uses a boud rate of 4800. I made this configurable in the settings with old_protocol.